### PR TITLE
update example file and update tf to use the new helm ng repo

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,12 +1,15 @@
 module "delegate" {
   source = "harness/kubernetes-delegate/harness"
-  version = "0.1.1"
+  version = "0.1.5"
 
-  account_id = "ABC123"
-  delegate_token = "XYZ789"
+  account_id = ""
+  delegate_token = ""
   delegate_name = "example"
   namespace = "harness-delegate-ng"
   manager_endpoint = "https://app.harness.io/gratis"
+  # delegate_image = "harness/delegate:22.11.77802"
+  replica = 1
+  upgrader_enabled = false
 
   # Additional optional values to pass to the helm chart
   values = yamlencode({

--- a/vars.tf
+++ b/vars.tf
@@ -1,7 +1,7 @@
 variable "helm_repository" {
   description = "The Helm repository to use."
   type        = string
-  default     = "https://app.harness.io/storage/harness-download/harness-helm-charts/"
+  default     = "https://app.harness.io/storage/harness-download/delegate-helm-chart/"
 }
 
 variable "namespace" {


### PR DESCRIPTION
Status: Tested - It's using the latest helm chart as expected
<img width="723" alt="Screen Shot 2023-01-09 at 1 27 36 PM" src="https://user-images.githubusercontent.com/109999795/211412389-3bb56323-3101-403e-9da9-83ba682fb39f.png">

Delegate comes up as expected.

<img width="669" alt="Screen Shot 2023-01-09 at 1 45 43 PM" src="https://user-images.githubusercontent.com/109999795/211414595-9a6ccf06-e414-411f-9f0a-b7a84035a9b2.png">
