### PR TITLE
fix:[DEL-6031]: add init script setting in terraform. fix some formats

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -8,12 +8,12 @@ module "delegate" {
   namespace = "harness-delegate-ng"
   manager_endpoint = "PUT_YOUR_MANAGER_URL"
   delegate_image = "PUT_YOUR_DELEGATE_IMAGE"
-  replica = 1
+  replicas = 1
   upgrader_enabled = false
 
   # Additional optional values to pass to the helm chart
   values = yamlencode({
-    javaOpts: "-Xms64M" 
+    initScript: ""
   })
 }
 

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,8 @@ locals {
     proxyHost            = var.proxy_host,
     proxyPort            = var.proxy_port,
     proxyScheme          = var.proxy_scheme,
-    noProxy              = var.no_proxy
+    noProxy              = var.no_proxy,
+    initScript           = var.init_script
   })
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -36,7 +36,6 @@ variable "delegate_token" {
 variable "manager_endpoint" {
   description = "The endpoint of Harness Manager."
   type        = string
-  // default     = "https://app.harness.io/gratis"
 }
 
 variable "replicas" {
@@ -55,42 +54,44 @@ variable "proxy_user" {
   description = "The proxy user to use for the Harness delegate."
   type        = string
   // sensitive = true
-  default = ""
+  default     = ""
 }
 
 variable "proxy_password" {
   description = "The proxy password to use for the Harness delegate."
   type        = string
   // sensitive = true
-  default = ""
+  default     = ""
 }
 
 variable "proxy_host" {
   description = "The proxy host."
   type        = string
-  // sensitive = true
-  default = ""
+  default     = ""
 }
 
 variable "proxy_port" {
   description = "The port of the proxy"
   type        = string
-  // sensitive = true
-  default = ""
+  default     = ""
 }
 
 variable "proxy_scheme" {
   description = "The proxy user to use for the Harness delegate."
   type        = string
-  // sensitive = true
-  default = ""
+  default     = ""
 }
 
 variable "no_proxy" {
   description = "Enter a comma-separated list of suffixes that do not need the proxy. For example, .company.com,hostname,etc. Do not use leading wildcards."
   type        = string
-  // sensitive = true
-  default = ""
+  default     = ""
+}
+
+variable "init_script" {
+  description = "Init Script"
+  type        = string
+  default     = ""
 }
 
 variable "values" {


### PR DESCRIPTION
1. provide example of how to set init script using current release 0.15 of terraform module
2. Bring init script as first class variable in terraform module

Test:
Tested with local delegate deployment. Verified that init script has been set 

<img width="1415" alt="image" src="https://user-images.githubusercontent.com/109999795/221345828-6d49254e-0999-4a11-80fd-0991af32029e.png">
<img width="1183" alt="image" src="https://user-images.githubusercontent.com/109999795/221345845-c0608b9a-2185-4a6a-8833-efed8801acf8.png">
