### PR TITLE
fix: [PL-32483]: remove provider in module

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,0 @@
-provider "helm" {
-
-  kubernetes {
-    config_path = "~/.kube/config"
-  }
-
-}


### PR DESCRIPTION
After experiment, it turns out that the remote delegate's helm provider will override the local user's helm provider setting.
We should not give default provider in delegate module 