### PR TITLE
fix: [PL-40699]: bump helm provider version to 2.9

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.5.1"
+      version = "2.9.0"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
bump helm version to 2.9
Although the latest is 2.10.1, customer openAI is using 2.9, it's more compatible with this customer's environment. On the other hand, taking a version that is 2 month back instead of the very recent one is good for stability.

Test:
Delegate can start successfully
<img width="1743" alt="image" src="https://github.com/harness/terraform-kubernetes-harness-delegate/assets/109999795/3fe6c991-37af-451e-8b00-0e4d0dc6382c">
