### PR TITLE
 bump helm provider constraint to >= 2.9

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.9.0"
+      version = ">= 2.9.0"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
This is breaking in projects that use a newer version of Helm

we could also change the constraint to `~> 2` to avoid major version change, but we should be fine with just minors