### PR TITLE
Chore: Bump Helm provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "~2"
+      version = "~> 2.9"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
We use a newer version of Helm in our current IaC projects,  and this hard constraint prevents us from installing the delegate using Terraform.

What changed:

Change Version Constraint to allow updates of minor versions and patches.

We tested this by installing the module from the [forked repo ](https://registry.terraform.io/modules/replit/harness-delegate/kubernetes/latest)