### PR TITLE
fix: Treat delegateToken as a sensitive input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,12 +6,19 @@ resource "helm_release" "delegate" {
   create_namespace = var.create_namespace
 
   values = [data.utils_deep_merge_yaml.values.output]
+
+  # ref https://github.com/hashicorp/terraform-provider-helm/pull/480
+  set_sensitive {
+    name  = "delegateToken"
+    value = var.delegate_token
+    type = "string"
+  }
+
 }
 
 locals {
   values = yamlencode({
     accountId            = var.account_id,
-    delegateToken        = var.delegate_token,
     managerEndpoint      = var.manager_endpoint,
     namespace            = var.namespace,
     delegateName         = var.delegate_name,


### PR DESCRIPTION
Hey Harness people! Found this little issue that is causing the delegateToken to be exposed as a simple string, this seems like it should be treated as a sensitive value.

I tested this change locally and it seems to fix the problem.

````
  # module.harness_delegate.module.delegate.helm_release.delegate will be updated in-place
  ~ resource "helm_release" "delegate" {
        id                         = "harness-delegate"
        name                       = "harness-delegate"
      ~ values                     = [
          - <<-EOT
                accountId:  randomAccountID
                delegateDockerImage: harness/delegate:24.07.83606
                delegateName: harness-delegate
                **delegateToken: REDACTED_BUT_THIS_WAS_EXPOSED_TO_THE_CI_PIPELINE**
                deployMode: KUBERNETES
                initScript: ""
                managerEndpoint: https://app.harness.io/gratis
                namespace: harness
                nextGen: true
                noProxy: ""
                proxyHost: ""
                proxyPassword: ""
                proxyPort: ""
                proxyScheme: ""
                proxyUser: ""
                replicas: 1
                upgrader:
                  enabled: true
            EOT,
          + <<-EOT
                accountId: randomAccountID
                delegateDockerImage: harness/delegate:24.07.83606
                delegateName: harness-delegate
                deployMode: KUBERNETES
                initScript: ""
                managerEndpoint: https://app.harness.io/gratis
                namespace: harness
                nextGen: true
                noProxy: ""
                proxyHost: ""
                proxyPassword: ""
                proxyPort: ""
                proxyScheme: ""
                proxyUser: ""
                replicas: 1
                upgrader:
                  enabled: true
            EOT,
        ]
        # (27 unchanged attributes hidden)

      + set_sensitive {
          + name  = "delegateToken"
          + type  = "string"
          + value = (sensitive value)
        }
    }
````