### PR TITLE
fix: [PL-63647]: restrict helm version because of breakig change in helm 3.0.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9.0"
+      version = ">= 2.9.0, < 3.0.0-0"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
version = ">= 2.9.0, < 3.0.0-0"

Restricted the version because of the breaking change in helm. Added -0 to prevent using helm 3.0 pre release versions
Helm release doc - https://github.com/hashicorp/terraform-provider-helm/blob/main/docs/guides/v3-upgrade-guide.md#changes-in-v300