### PR TITLE
feat: [PL-40647]: Added mtls support in delegate terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_proxy_user"></a> [proxy\_user](#input\_proxy\_user) | The proxy user to use for the Harness delegate. | `string` | `""` | no |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | replica count of delegates. | `number` | `1` | no |
 | <a name="input_upgrader_enabled"></a> [upgrader\_enabled](#input\_upgrader\_enabled) | Is upgrader enabled | `bool` | `true` | no |
+| <a name="input_mtls_secret_name"></a> [mtls\_secret\_name](#input\_mtls\_secret\_name) | The name of the mTLS secret. | `string` | `""` | no |
 | <a name="input_values"></a> [values](#input\_values) | Additional values to pass to the helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,7 @@ locals {
     noProxy              = var.no_proxy,
     initScript           = var.init_script,
     deployMode           = var.deploy_mode
+    mTLS                 = { secretName = var.mtls_secret_name } 
   })
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -68,6 +68,12 @@ variable "upgrader_enabled" {
   default     = true
 }
 
+variable "mtls_secret_name" {
+  description = "The name of the mTLS secret."
+  type        = string
+  default     = ""
+}
+
 variable "proxy_user" {
   description = "The proxy user to use for the Harness delegate."
   type        = string


### PR DESCRIPTION
RESULT: The mTLS secret is mounted as a volume in the pod when installing delegate using terraform module

<img width="180" height="60" alt="Screenshot 2025-08-04 at 1 06 19 PM" src="https://github.com/user-attachments/assets/ff1942ba-ac61-49b2-ad83-dd4690831b8b" />
